### PR TITLE
Fix patch response check

### DIFF
--- a/src/entity.js
+++ b/src/entity.js
@@ -248,7 +248,8 @@ jDrupal.Entity.prototype.save = function() {
           _entity.postSave(req).then(function() {
             if (
               (method == 'POST' && req.status == 201) ||
-              (method == 'PATCH' && req.status == 204)
+              (method == 'PATCH' && req.status == 204) ||
+              req.status == 200
             ) {
               var invoke = jDrupal.moduleInvokeAll('rest_post_process', req);
               if (!invoke) { resolve(); }


### PR DESCRIPTION
in /src/entity.js

The function jDrupal.Entity.prototype.save expects the response code to be 201 or 204 to be considered 'valid', however when i run a patch to update a node I get the response 200.

Not sure why there is a discrepancy here, maybe core has updated the response codes as I'm using Drupal 8.3