### PR TITLE
postsave() fix

### DIFF
--- a/src/entity.js
+++ b/src/entity.js
@@ -278,7 +278,7 @@ jDrupal.Entity.prototype.postSave = function(xhr) {
   var self = this;
   return new Promise(function(resolve, reject) {
     // For new entities, grab their id from the Location response header.
-    if (self.isNew()) {
+    if (self.isNew() && xhr.getResponseHeader('Location')) {
       var parts = xhr.getResponseHeader('Location').split('/');
       var entityID =
         self.entity[self.getEntityKey('id')] = [ {


### PR DESCRIPTION
If an entity patch/post request fails such as a validation error then no 'Location' header is returned in the response, this then bugs out when trying to split() it.

I've just added an extra clause to only do it if a location header exists.