### PR TITLE
Added main option to bower.json for wiredep support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,9 @@
   "authors": [
     "Tyler Frankenstein <email@tylerfrankenstein.com>"
   ],
+  "main": [
+    "jdrupal.min.js",
+  ],
   "description": "A JavaScript library for Drupal 8 REST.",
   "keywords": [
     "drupal"


### PR DESCRIPTION
I'm using wiredep to automatically inject bower dependencies into my project and jDrupal doesn't have the "main" option set in bower.json, so wiredep doesn't know which file to inject.  This is a quick pull request that links directly to the main minified file.

Reference:
https://github.com/taptapship/wiredep#bower-overrides

As stated on the wiredep readme, it's not the only service that relies upon the main option to grab the proper file.