### PR TITLE
Use newer token session route

### DIFF
--- a/src/includes/rest.inc.js
+++ b/src/includes/rest.inc.js
@@ -30,7 +30,7 @@ jDrupal.token = function() {
       service: 'system',
       resource: 'token'
     };
-    req.open('GET', jDrupal.restPath() + 'rest/session/token');
+    req.open('GET', jDrupal.restPath() + 'session/token');
     req.onload = function() {
       if (req.status == 200) {
         var invoke = jDrupal.moduleInvokeAll('rest_post_process', req);


### PR DESCRIPTION
rest.routing.yml:

```yaml
# @deprecated This route is deprecated, use the system.csrftoken route from the
# system module instead.
# @todo Remove this route in Drupal 9.0.0.
rest.csrftoken:
  path: '/rest/session/token'
```

system.routing.yml
```yaml
system.csrftoken:
  path: '/session/token'
```

Not urgent, but worth doing.
