### PR TITLE
Rename variable with a reserved word

### DIFF
--- a/src/includes/module.inc.js
+++ b/src/includes/module.inc.js
@@ -23,15 +23,15 @@ jDrupal.moduleExists = function (name) {
  * @return {Array}
  */
 jDrupal.moduleImplements = function(hook) {
-  var implements = [];
+  var implementations = [];
   for (var module in jDrupal.modules) {
     if (jDrupal.modules.hasOwnProperty(module)) {
       if (jDrupal.functionExists(module + '_' + hook)) {
-        implements.push(module);
+        implementations.push(module);
       }
     }
   }
-  return implements.length ? implements : false;
+  return implementations.length ? implementations : false;
 };
 
 /**


### PR DESCRIPTION
I was getting:

`implements is a reserved word in strict mode`

In a build where I used this project for years and saw this new commits.

I will fallback to an older version for now until I update to D9 and then I might try it out, I hope you can merge this one soonish.

Thanks!